### PR TITLE
add possibility to open PageTable items in new tab

### DIFF
--- a/wire/modules/Inputfield/InputfieldPageTable/InputfieldPageTable.module
+++ b/wire/modules/Inputfield/InputfieldPageTable/InputfieldPageTable.module
@@ -446,7 +446,7 @@ class InputfieldPageTable extends Inputfield {
 	 */
 	protected function renderItemLink(Page $item, $out, $url = '') {
 		if(!$url) $url = $this->getItemEditURL($item);
-		return "<a class='InputfieldPageTableEdit' data-url='$url' href='#'>$out</a>";
+		return "<a class='InputfieldPageTableEdit' data-url='$url' href='$url'>$out</a>";
 	}
 
 	/**


### PR DESCRIPTION
This simple change enables us to open the link of a PageTable item in a new tab via right click or middle click instead of a modal dialog. The normal modal dialog behaviour is still working if you use a simple click.